### PR TITLE
[Feature request] Enable to choose if use uploader

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,11 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 });
 ```
+
+### Options
+
+#### useUploader
+- type: Boolean
+- default: true
+
+Enable uploading files on drop when the value is set to true

--- a/lib/textarea-markdown.js
+++ b/lib/textarea-markdown.js
@@ -26,6 +26,7 @@ var TextareaMarkdown = function () {
 
     this.textarea = textarea;
     this.options = Object.assign({
+      useUploader: true,
       endPoint: '/api/image.json',
       paramName: 'file',
       responseKey: 'url',
@@ -43,9 +44,11 @@ var TextareaMarkdown = function () {
     this.previews = [];
     this.setPreview();
     this.applyPreview();
-    textarea.addEventListener("drop", function (e) {
-      return _this.drop(e);
-    });
+    if (this.options.useUploader) {
+      textarea.addEventListener("drop", function (e) {
+        return _this.drop(e);
+      });
+    }
     textarea.addEventListener("paste", function (e) {
       return _this.paste(e);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "textarea-markdown",
-  "version": "1.2.7",
+  "version": "1.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/textarea-markdown.js
+++ b/src/textarea-markdown.js
@@ -5,6 +5,7 @@ export default class TextareaMarkdown {
   constructor(textarea, options = {}) {
     this.textarea = textarea;
     this.options = Object.assign({
+      useUploader: true,
       endPoint: '/api/image.json',
       paramName: 'file',
       responseKey: 'url',
@@ -22,7 +23,9 @@ export default class TextareaMarkdown {
     this.previews = [];
     this.setPreview();
     this.applyPreview();
-    textarea.addEventListener("drop", e => this.drop(e));
+    if(this.options.useUploader) {
+      textarea.addEventListener("drop", e => this.drop(e));
+    }
     textarea.addEventListener("paste", e => this.paste(e));
     textarea.addEventListener("keyup", e => this.keyup(e));
   }


### PR DESCRIPTION
突然失礼します。
こちらのライブラリを使用させていただいておりますが、画像をアップロードする必要がない（apiがない）案件がありました。
そういった際にファイルをドラッグ&ドロップしたときの挙動はブラウザのデフォルトのものが良いかと思い、オプションを追加させていただきました。
よろしければマージをお願いいたします。

---

I want not to bind uploading function on drop event.
With option `useUploader` set to `false` it would not upload files and it behave as browser's default.
