### PR TITLE
feat: add uploading by file selection dialog option

### DIFF
--- a/lib/textarea-markdown.js
+++ b/lib/textarea-markdown.js
@@ -50,6 +50,8 @@ var TextareaMarkdown = function () {
     this.previews = [];
     this.setPreview();
     this.applyPreview();
+    this.inputelements = [];
+    this.setInputElement();
     if (this.options.useUploader) {
       textarea.addEventListener("dragover", function (e) {
         return e.preventDefault();
@@ -64,6 +66,9 @@ var TextareaMarkdown = function () {
     textarea.addEventListener("keyup", function (e) {
       return _this.keyup(e);
     });
+    this.inputelements.addEventListener("change", function (e) {
+      return _this.input(e);
+    });
   }
 
   _createClass(TextareaMarkdown, [{
@@ -76,6 +81,14 @@ var TextareaMarkdown = function () {
         Array.from(document.querySelectorAll(selector), function (e) {
           return _this2.previews.push(e);
         });
+      }
+    }
+  }, {
+    key: "setInputElement",
+    value: function setInputElement() {
+      var selector = this.textarea.getAttribute("data-input");
+      if (selector) {
+        this.inputelements = document.querySelector(selector);
       }
     }
   }, {
@@ -97,6 +110,14 @@ var TextareaMarkdown = function () {
     key: "keyup",
     value: function keyup() {
       this.applyPreview();
+    }
+  }, {
+    key: "input",
+    value: function input(event) {
+      var files = event.target.files;
+      if (files.length > 0) {
+        this.uploadAll(event.target.files);
+      }
     }
   }, {
     key: "triggerEvent",

--- a/lib/textarea-markdown.js
+++ b/lib/textarea-markdown.js
@@ -36,7 +36,7 @@ var TextareaMarkdown = function () {
       responseKey: "url",
       csrfToken: null,
       placeholder: "uploading %filename ...",
-      imageableExtensions: ["jpeg", "png", "gif"],
+      imageableExtensions: ["jpg", "png", "gif"],
       videoExtensions: ["mov", "mp4", "webm"],
       afterPreview: function afterPreview() {},
       plugins: [],
@@ -65,6 +65,9 @@ var TextareaMarkdown = function () {
     });
     textarea.addEventListener("keyup", function (e) {
       return _this.keyup(e);
+    });
+    this.inputelements.addEventListener('click', function (e) {
+      return e.target.value = '';
     });
     this.inputelements.addEventListener("change", function (e) {
       return _this.input(e);
@@ -173,7 +176,7 @@ var TextareaMarkdown = function () {
       reader.readAsArrayBuffer(file);
       reader.onload = async function () {
         var bytes = new Uint8Array(reader.result);
-        var fileType = await FileType.fromStream(bytes)["ext"];
+        var fileType = await FileType.fromBuffer(bytes);
         var fileSize = (0, _filesize.filesize)(file.size, { base: 10, standard: "jedec" });
         var text = "![" + _this5.options["placeholder"].replace(/\%filename/, file.name) + "]()";
 
@@ -201,9 +204,9 @@ var TextareaMarkdown = function () {
         }).then(function (json) {
           var responseKey = _this5.options["responseKey"];
           var url = json[responseKey];
-          if (_this5.options["imageableExtensions"].includes(fileType)) {
+          if (_this5.options["imageableExtensions"].includes(fileType.ext)) {
             _this5.textarea.value = _this5.textarea.value.replace(text, "![" + file.name + "](" + url + ")\n");
-          } else if (_this5.options["videoExtensions"].includes(fileType)) {
+          } else if (_this5.options["videoExtensions"].includes(fileType.ext)) {
             _this5.textarea.value = _this5.textarea.value.replace(text, "<video controls src=\"" + url + "\"></video>\n");
           } else {
             _this5.textarea.value = _this5.textarea.value.replace(text, "[" + file.name + " (" + fileSize + ")](" + url + ")\n");

--- a/lib/textarea-markdown.js
+++ b/lib/textarea-markdown.js
@@ -89,7 +89,7 @@ var TextareaMarkdown = function () {
   }, {
     key: "setInputElement",
     value: function setInputElement() {
-      var selector = this.textarea.getAttribute("data-input");
+      var selector = this.textarea.getAttribute("file-input");
       if (selector) {
         this.inputelements = document.querySelector(selector);
       }

--- a/src/textarea-markdown.js
+++ b/src/textarea-markdown.js
@@ -52,7 +52,7 @@ export default class TextareaMarkdown {
   }
 
   setInputElement() {
-    const selector = this.textarea.getAttribute("data-input");
+    const selector = this.textarea.getAttribute("file-input");
     if (selector) {
       this.inputelements = document.querySelector(selector);
     }

--- a/src/textarea-markdown.js
+++ b/src/textarea-markdown.js
@@ -30,12 +30,15 @@ export default class TextareaMarkdown {
     this.previews = [];
     this.setPreview();
     this.applyPreview();
+    this.inputelements = [];
+    this.setInputElement();
     if (this.options.useUploader) {
       textarea.addEventListener("dragover", (e) => e.preventDefault());
       textarea.addEventListener("drop", (e) => this.drop(e));
     }
     textarea.addEventListener("paste", (e) => this.paste(e));
     textarea.addEventListener("keyup", (e) => this.keyup(e));
+    this.inputelements.addEventListener("change", (e) => this.input(e));
   }
 
   setPreview() {
@@ -44,6 +47,13 @@ export default class TextareaMarkdown {
       Array.from(document.querySelectorAll(selector), (e) =>
         this.previews.push(e)
       );
+    }
+  }
+
+  setInputElement() {
+    const selector = this.textarea.getAttribute("data-input");
+    if (selector) {
+      this.inputelements = document.querySelector(selector);
     }
   }
 
@@ -62,6 +72,13 @@ export default class TextareaMarkdown {
 
   keyup() {
     this.applyPreview();
+  }
+
+  input(event) {
+    const files = event.target.files;
+    if (files.length > 0) {
+      this.uploadAll(event.target.files);
+    }
   }
 
   triggerEvent(element, event) {

--- a/src/textarea-markdown.js
+++ b/src/textarea-markdown.js
@@ -52,7 +52,7 @@ export default class TextareaMarkdown {
   }
 
   setInputElement() {
-    const selector = this.textarea.getAttribute("file-input");
+    const selector = this.textarea.getAttribute("data-input");
     if (selector) {
       this.inputelements = document.querySelector(selector);
     }

--- a/src/textarea-markdown.js
+++ b/src/textarea-markdown.js
@@ -38,6 +38,7 @@ export default class TextareaMarkdown {
     }
     textarea.addEventListener("paste", (e) => this.paste(e));
     textarea.addEventListener("keyup", (e) => this.keyup(e));
+    this.inputelements.addEventListener('click', (e) => e.target.value = '');
     this.inputelements.addEventListener("change", (e) => this.input(e));
   }
 


### PR DESCRIPTION
I have added a file attachment feature using a file selection dialog. You can use it by linking a `<input>` element with a specified class to a text area or preview.

![画面収録_2023-06-07_0_30_23_AdobeExpress](https://github.com/komagata/textarea-markdown/assets/69577164/9769df2a-aced-45c1-ac36-d8861f9ba1ad)
In the confirmation image, I am using a branch that includes bug fix #37.