### PR TITLE
support file upload by file selection dialog | forgot to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install textarea-markdown
 ```javascript
 import TextareaMarkdown from 'textarea-markdown'
 
-let textarea = document.querySelector("textarea");
+let textarea = document.querySelector('textarea');
 new TextareaMarkdown(textarea);
 ```
 
@@ -56,3 +56,22 @@ document.addEventListener('DOMContentLoaded', () => {
 - default: true
 
 Enable uploading files on drop when the value is set to true
+
+#### file upload by file selection dialog
+Enable uploading files by file selection dialog when using `<input>` as in the following code
+
+```html
+<h2>Editor & File input</h2>
+<input type="file" class="data-input">
+<textarea id="editor" data-preview="#preview" data-input=".input"></textarea>
+
+<h2>Preview</h2>
+<div id="preview"></div>
+```
+
+```javascript
+import TextareaMarkdown from 'textarea-markdown'
+
+let textarea = document.querySelector('textarea');
+new TextareaMarkdown(textarea);
+```

--- a/lib/textarea-markdown.js
+++ b/lib/textarea-markdown.js
@@ -36,7 +36,7 @@ var TextareaMarkdown = function () {
       responseKey: "url",
       csrfToken: null,
       placeholder: "uploading %filename ...",
-      imageableExtensions: ["jpeg", "png", "gif"],
+      imageableExtensions: ["jpg", "png", "gif"],
       videoExtensions: ["mov", "mp4", "webm"],
       afterPreview: function afterPreview() {},
       plugins: [],
@@ -50,6 +50,7 @@ var TextareaMarkdown = function () {
     this.previews = [];
     this.setPreview();
     this.applyPreview();
+    var inputelement = this.setInputElement();
     if (this.options.useUploader) {
       textarea.addEventListener("dragover", function (e) {
         return e.preventDefault();
@@ -64,6 +65,14 @@ var TextareaMarkdown = function () {
     textarea.addEventListener("keyup", function (e) {
       return _this.keyup(e);
     });
+    if (inputelement) {
+      inputelement.addEventListener('click', function (e) {
+        return e.target.value = '';
+      });
+      inputelement.addEventListener("change", function (e) {
+        return _this.input(e);
+      });
+    }
   }
 
   _createClass(TextareaMarkdown, [{
@@ -76,6 +85,14 @@ var TextareaMarkdown = function () {
         Array.from(document.querySelectorAll(selector), function (e) {
           return _this2.previews.push(e);
         });
+      }
+    }
+  }, {
+    key: "setInputElement",
+    value: function setInputElement() {
+      var selector = this.textarea.getAttribute("data-input");
+      if (selector) {
+        return document.querySelector(selector);
       }
     }
   }, {
@@ -97,6 +114,14 @@ var TextareaMarkdown = function () {
     key: "keyup",
     value: function keyup() {
       this.applyPreview();
+    }
+  }, {
+    key: "input",
+    value: function input(event) {
+      var files = event.target.files;
+      if (files.length > 0) {
+        this.uploadAll(event.target.files);
+      }
     }
   }, {
     key: "triggerEvent",
@@ -152,7 +177,7 @@ var TextareaMarkdown = function () {
       reader.readAsArrayBuffer(file);
       reader.onload = async function () {
         var bytes = new Uint8Array(reader.result);
-        var fileType = await FileType.fromStream(bytes)["ext"];
+        var fileType = await FileType.fromBuffer(bytes);
         var fileSize = (0, _filesize.filesize)(file.size, { base: 10, standard: "jedec" });
         var text = "![" + _this5.options["placeholder"].replace(/\%filename/, file.name) + "]()";
 
@@ -180,9 +205,9 @@ var TextareaMarkdown = function () {
         }).then(function (json) {
           var responseKey = _this5.options["responseKey"];
           var url = json[responseKey];
-          if (_this5.options["imageableExtensions"].includes(fileType)) {
+          if (_this5.options["imageableExtensions"].includes(fileType.ext)) {
             _this5.textarea.value = _this5.textarea.value.replace(text, "![" + file.name + "](" + url + ")\n");
-          } else if (_this5.options["videoExtensions"].includes(fileType)) {
+          } else if (_this5.options["videoExtensions"].includes(fileType.ext)) {
             _this5.textarea.value = _this5.textarea.value.replace(text, "<video controls src=\"" + url + "\"></video>\n");
           } else {
             _this5.textarea.value = _this5.textarea.value.replace(text, "[" + file.name + " (" + fileSize + ")](" + url + ")\n");

--- a/lib/textarea-markdown.js
+++ b/lib/textarea-markdown.js
@@ -18,7 +18,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var FileType = require('file-type/browser');
+var FileType = require("file-type/browser");
 
 var TextareaMarkdown = function () {
   function TextareaMarkdown(textarea) {
@@ -66,8 +66,8 @@ var TextareaMarkdown = function () {
       return _this.keyup(e);
     });
     if (inputelement) {
-      inputelement.addEventListener('click', function (e) {
-        return e.target.value = '';
+      inputelement.addEventListener("click", function (e) {
+        return e.target.value = "";
       });
       inputelement.addEventListener("change", function (e) {
         return _this.input(e);

--- a/src/textarea-markdown.js
+++ b/src/textarea-markdown.js
@@ -1,6 +1,6 @@
 import "whatwg-fetch";
 import MarkdownIt from "markdown-it";
-const FileType = require('file-type/browser');
+const FileType = require("file-type/browser");
 import { filesize } from "filesize";
 
 export default class TextareaMarkdown {
@@ -38,7 +38,7 @@ export default class TextareaMarkdown {
     textarea.addEventListener("paste", (e) => this.paste(e));
     textarea.addEventListener("keyup", (e) => this.keyup(e));
     if (inputelement) {
-      inputelement.addEventListener('click', (e) => e.target.value = '');
+      inputelement.addEventListener("click", (e) => e.target.value = "");
       inputelement.addEventListener("change", (e) => this.input(e));
     }
   }

--- a/src/textarea-markdown.js
+++ b/src/textarea-markdown.js
@@ -30,12 +30,17 @@ export default class TextareaMarkdown {
     this.previews = [];
     this.setPreview();
     this.applyPreview();
+    const inputelement = this.setInputElement();
     if (this.options.useUploader) {
       textarea.addEventListener("dragover", (e) => e.preventDefault());
       textarea.addEventListener("drop", (e) => this.drop(e));
     }
     textarea.addEventListener("paste", (e) => this.paste(e));
     textarea.addEventListener("keyup", (e) => this.keyup(e));
+    if (inputelement) {
+      inputelement.addEventListener('click', (e) => e.target.value = '');
+      inputelement.addEventListener("change", (e) => this.input(e));
+    }
   }
 
   setPreview() {
@@ -44,6 +49,13 @@ export default class TextareaMarkdown {
       Array.from(document.querySelectorAll(selector), (e) =>
         this.previews.push(e)
       );
+    }
+  }
+
+  setInputElement() {
+    const selector = this.textarea.getAttribute("data-input");
+    if (selector) {
+      return document.querySelector(selector);
     }
   }
 
@@ -62,6 +74,13 @@ export default class TextareaMarkdown {
 
   keyup() {
     this.applyPreview();
+  }
+
+  input(event) {
+    const files = event.target.files;
+    if (files.length > 0) {
+      this.uploadAll(event.target.files);
+    }
   }
 
   triggerEvent(element, event) {


### PR DESCRIPTION
## Purpose, background
Attaching a file to a text area is not always done by drag-and-drop only, so I thought it would be more convenient to provide an optional attachment method using a file selection dialog in this npm library.

## Details
I have added support for file uploads using `<input>`, which is now linked to a text area and a preview. The following code is an example. By associating the `<textarea>` with an ID or a selector, the local file called using `<input>` will be attached to the text area.

```html
<h2>Editor & File input</h2>
<input type="file" class="data-input">
<textarea id="editor" data-preview="#preview" data-input=".input"></textarea>

<h2>Preview</h2>
<div id="preview"></div>
```

## How to check
01. Install using npm install https://github.com/YukiWatanabe824/textarea-markdown#feature/add_file_selection_dialog_option.
01. You can confirm the functionality with the following usage example.
```html
<h2>Editor & File input</h2>
<input type="file" class="data-input">
<textarea id="editor" data-preview="#preview" data-input=".input"></textarea>

<h2>Preview</h2>
<div id="preview"></div>
```
```javascript
import TextareaMarkdown from 'textarea-markdown'

let textarea = document.querySelector("textarea");
new TextareaMarkdown(textarea);
```