### PR TITLE
Added the ability to set tags on upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ document.addEventListener('DOMContentLoaded', () => {
     paramName: 'file',
     responseKey: 'url',
     csrfToken: token,
-    placeholder: 'uploading %filename ...'
+    placeholder: 'uploading %filename ...',
+    uploadImageTag: '<img src=%url width="100" height="100" alt="%filename">\n',
   })
 });
 ```

--- a/lib/textarea-markdown.js
+++ b/lib/textarea-markdown.js
@@ -40,6 +40,9 @@ var TextareaMarkdown = function () {
       videoExtensions: ["mov", "mp4", "webm"],
       afterPreview: function afterPreview() {},
       plugins: [],
+      uploadImageTag: "![%filename](%url)\n",
+      uploadVideoTag: '<video controls src="%url"></video>\n',
+      uploadOtherTag: "[%filename (%fileSize)](%url)\n",
       markdownOptions: Object.assign({
         html: true,
         breaks: true,
@@ -179,7 +182,7 @@ var TextareaMarkdown = function () {
         var bytes = new Uint8Array(reader.result);
         var fileType = await FileType.fromBuffer(bytes);
         var fileSize = (0, _filesize.filesize)(file.size, { base: 10, standard: "jedec" });
-        var text = "![" + _this5.options["placeholder"].replace(/\%filename/, file.name) + "]()";
+        var text = "![" + _this5.options["placeholder"].replace(/filename/, file.name) + "]()";
 
         var beforeRange = _this5.textarea.selectionStart;
         // const afterRange = text.length;
@@ -203,21 +206,38 @@ var TextareaMarkdown = function () {
         }).then(function (response) {
           return response.json();
         }).then(function (json) {
-          var responseKey = _this5.options["responseKey"];
+          var responseKey = _this5.options.responseKey;
           var url = json[responseKey];
-          if (_this5.options["imageableExtensions"].includes(fileType.ext)) {
-            _this5.textarea.value = _this5.textarea.value.replace(text, "![" + file.name + "](" + url + ")\n");
-          } else if (_this5.options["videoExtensions"].includes(fileType.ext)) {
-            _this5.textarea.value = _this5.textarea.value.replace(text, "<video controls src=\"" + url + "\"></video>\n");
-          } else {
-            _this5.textarea.value = _this5.textarea.value.replace(text, "[" + file.name + " (" + fileSize + ")](" + url + ")\n");
-          }
+          var placeholderTag = _this5.selectPlaceholderTag(fileType);
+          var uploadTag = _this5.replacePlaceholderTag(placeholderTag, file.name, fileSize, url);
+
+          _this5.textarea.value = _this5.textarea.value.replace(text, uploadTag);
           _this5.applyPreview();
         }).catch(function (error) {
           _this5.textarea.value = _this5.textarea.value.replace(text, "");
           console.warn("parsing failed", error);
         });
       };
+    }
+  }, {
+    key: "selectPlaceholderTag",
+    value: function selectPlaceholderTag(fileType) {
+      if (this.options.imageableExtensions.includes(fileType.ext)) {
+        return this.options.uploadImageTag;
+      } else if (this.options.videoExtensions.includes(fileType.ext)) {
+        return this.options.uploadVideoTag;
+      } else {
+        return this.options.uploadOtherTag;
+      }
+    }
+  }, {
+    key: "replacePlaceholderTag",
+    value: function replacePlaceholderTag(placeholderTag, filename, fileSize, url) {
+      if (placeholderTag !== this.options.uploadOtherTag) {
+        return placeholderTag.replace(/%filename/, filename).replace(/%url/, url);
+      } else {
+        return placeholderTag.replace(/%filename/, filename).replace(/%url/, url).replace(/%fileSize/, fileSize);
+      }
     }
   }]);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textarea-markdown",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Make textarea a markdown editor.",
   "main": "lib/textarea-markdown.js",
   "scripts": {


### PR DESCRIPTION
@komagata Hello!

I would like to update textarea-markdown in relation to [this PR](https://github.com/fjordllc/bootcamp/pull/7299) in the [bootcamp app](https://github.com/fjordllc/bootcamp). Please check the content.

# Change Summary

The tag for uploading a file to the text area can be set in the instance creation argument. The default setting is the same as before.

# before

Previously, it was fixed with the following tags.

<img width="416" alt="image" src="https://github.com/komagata/textarea-markdown/assets/90775541/77ade70c-3a4f-4d9f-8df5-4c1b87688c5b">

# after

The tag can now be adjusted in the options during instance creation, as shown below.

```js
      new TextareaMarkdown(textarea, {
        endPoint: '/api/image.json',
        paramName: 'file',
        responseKey: 'url',
        csrfToken: CSRF.getToken(),
        placeholder: '%filename uploading...',
        uploadImageTag:
          '<img src=%url width="100" height="100" loading="lazy" decoding="async" alt="%filename">\n',
        ...
```

![image](https://github.com/komagata/textarea-markdown/assets/90775541/a9715625-517b-40f9-b19c-49ec6cc03e3e)
