### PR TITLE
Added the ability to get the image dimensions when uploading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
     responseKey: 'url',
     csrfToken: token,
     placeholder: 'uploading %filename ...',
-    uploadImageTag: '<img src=%url width="100" height="100" alt="%filename">\n',
+    uploadImageTag: '<img src=%url width="%width" height="%height" alt="%filename">\n',
   })
 });
 ```

--- a/lib/textarea-markdown.js
+++ b/lib/textarea-markdown.js
@@ -164,17 +164,36 @@ var TextareaMarkdown = function () {
     value: function uploadToOriginal() {}
   }, {
     key: "uploadAll",
-    value: function uploadAll(files) {
-      var _this4 = this;
+    value: async function uploadAll(files) {
+      var _iteratorNormalCompletion = true;
+      var _didIteratorError = false;
+      var _iteratorError = undefined;
 
-      Array.from(files, function (f) {
-        return _this4.upload(f);
-      });
+      try {
+        for (var _iterator = files[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+          var file = _step.value;
+
+          await this.upload(file);
+        }
+      } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion && _iterator.return) {
+            _iterator.return();
+          }
+        } finally {
+          if (_didIteratorError) {
+            throw _iteratorError;
+          }
+        }
+      }
     }
   }, {
     key: "upload",
-    value: function upload(file) {
-      var _this5 = this;
+    value: async function upload(file) {
+      var _this4 = this;
 
       var reader = new FileReader();
       reader.readAsArrayBuffer(file);
@@ -182,41 +201,42 @@ var TextareaMarkdown = function () {
         var bytes = new Uint8Array(reader.result);
         var fileType = await FileType.fromBuffer(bytes);
         var fileSize = (0, _filesize.filesize)(file.size, { base: 10, standard: "jedec" });
-        var text = "![" + _this5.options["placeholder"].replace(/filename/, file.name) + "]()";
+        var text = "![" + _this4.options["placeholder"].replace(/filename/, file.name) + "]()";
 
-        var beforeRange = _this5.textarea.selectionStart;
+        var beforeRange = _this4.textarea.selectionStart;
         // const afterRange = text.length;
-        var beforeText = _this5.textarea.value.substring(0, beforeRange);
-        var afterText = _this5.textarea.value.substring(beforeRange, _this5.textarea.value.length);
-        _this5.textarea.value = beforeText + "\n" + text + "\n" + afterText;
+        var beforeText = _this4.textarea.value.substring(0, beforeRange);
+        var afterText = _this4.textarea.value.substring(beforeRange, _this4.textarea.value.length);
+        _this4.textarea.value = beforeText + "\n" + text + "\n" + afterText;
 
         var params = new FormData();
-        params.append(_this5.options["paramName"], file);
+        params.append(_this4.options["paramName"], file);
 
         var headers = { "X-Requested-With": "XMLHttpRequest" };
-        if (_this5.options["csrfToken"]) {
-          headers["X-CSRF-Token"] = _this5.options["csrfToken"];
+        if (_this4.options["csrfToken"]) {
+          headers["X-CSRF-Token"] = _this4.options["csrfToken"];
         }
 
-        fetch(_this5.options["endPoint"], {
-          method: "POST",
-          headers: headers,
-          credentials: "same-origin",
-          body: params
-        }).then(function (response) {
-          return response.json();
-        }).then(function (json) {
-          var responseKey = _this5.options.responseKey;
+        try {
+          var response = await fetch(_this4.options["endPoint"], {
+            method: "POST",
+            headers: headers,
+            credentials: "same-origin",
+            body: params
+          });
+          var json = await response.json();
+          var responseKey = _this4.options.responseKey;
           var url = json[responseKey];
-          var placeholderTag = _this5.selectPlaceholderTag(fileType);
-          var uploadTag = _this5.replacePlaceholderTag(placeholderTag, file.name, fileSize, url);
+          var placeholderTag = _this4.selectPlaceholderTag(fileType);
 
-          _this5.textarea.value = _this5.textarea.value.replace(text, uploadTag);
-          _this5.applyPreview();
-        }).catch(function (error) {
-          _this5.textarea.value = _this5.textarea.value.replace(text, "");
+          var uploadTag = await _this4.replacePlaceholderTag(placeholderTag, file.name, fileSize, url);
+
+          _this4.textarea.value = _this4.textarea.value.replace(text, uploadTag);
+          _this4.applyPreview();
+        } catch (error) {
+          _this4.textarea.value = _this4.textarea.value.replace(text, "");
           console.warn("parsing failed", error);
-        });
+        }
       };
     }
   }, {
@@ -232,12 +252,31 @@ var TextareaMarkdown = function () {
     }
   }, {
     key: "replacePlaceholderTag",
-    value: function replacePlaceholderTag(placeholderTag, filename, fileSize, url) {
-      if (placeholderTag !== this.options.uploadOtherTag) {
-        return placeholderTag.replace(/%filename/, filename).replace(/%url/, url);
+    value: async function replacePlaceholderTag(placeholderTag, filename, fileSize, url) {
+      var commonPlaceholderTag = placeholderTag.replace(/%filename/, filename).replace(/%url/, url);
+
+      if (placeholderTag === this.options.uploadImageTag) {
+        var dimensions = await this.fetchImageDimensions(url);
+        return commonPlaceholderTag.replace(/%width/, dimensions.width).replace(/%height/, dimensions.height);
+      } else if (placeholderTag === this.options.uploadVideoTag) {
+        return commonPlaceholderTag;
       } else {
-        return placeholderTag.replace(/%filename/, filename).replace(/%url/, url).replace(/%fileSize/, fileSize);
+        return commonPlaceholderTag.replace(/%fileSize/, fileSize);
       }
+    }
+  }, {
+    key: "fetchImageDimensions",
+    value: function fetchImageDimensions(url) {
+      return new Promise(function (resolve, reject) {
+        var image = new Image();
+        image.onload = function () {
+          resolve({ width: image.width, height: image.height });
+        };
+        image.onerror = function (error) {
+          reject(error);
+        };
+        image.src = url;
+      });
     }
   }]);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textarea-markdown",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Make textarea a markdown editor.",
   "main": "lib/textarea-markdown.js",
   "scripts": {


### PR DESCRIPTION
@komagata Hello!

I would like to update textarea-markdown in relation to [this PR](https://github.com/fjordllc/bootcamp/pull/8009). Please check the content.

# Change Summary

The tag for uploading a file to the text area can be set in the instance creation argument. The default setting is the same as before.

# before

Previously, it was fixed with the following tags.

<img width="416" alt="image" src="https://github.com/komagata/textarea-markdown/assets/90775541/77ade70c-3a4f-4d9f-8df5-4c1b87688c5b">

# after

The tag can now be adjusted in the options during instance creation, as shown below.

```js
      new TextareaMarkdown(textarea, {
        ...
        uploadImageTag:
          '<img src=%url width="%width" height="%height" loading="lazy" decoding="async" alt="%filename">\n',
        ...
```

[![Image from Gyazo](https://i.gyazo.com/b5fa6e3629bbc8ecc06b9630b87878b8.png)](https://gyazo.com/b5fa6e3629bbc8ecc06b9630b87878b8)