### PR TITLE
If the uploadTag contains multiple target strings, replace all target strings.

### DIFF
--- a/lib/textarea-markdown.js
+++ b/lib/textarea-markdown.js
@@ -253,15 +253,15 @@ var TextareaMarkdown = function () {
   }, {
     key: "replacePlaceholderTag",
     value: async function replacePlaceholderTag(placeholderTag, filename, fileSize, url) {
-      var commonPlaceholderTag = placeholderTag.replace(/%filename/, filename).replace(/%url/, url);
+      var commonPlaceholderTag = placeholderTag.replace(/%filename/g, filename).replace(/%url/g, url);
 
       if (placeholderTag === this.options.uploadImageTag) {
         var dimensions = await this.fetchImageDimensions(url);
-        return commonPlaceholderTag.replace(/%width/, dimensions.width).replace(/%height/, dimensions.height);
+        return commonPlaceholderTag.replace(/%width/g, dimensions.width).replace(/%height/g, dimensions.height);
       } else if (placeholderTag === this.options.uploadVideoTag) {
         return commonPlaceholderTag;
       } else {
-        return commonPlaceholderTag.replace(/%fileSize/, fileSize);
+        return commonPlaceholderTag.replace(/%fileSize/g, fileSize);
       }
     }
   }, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textarea-markdown",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Make textarea a markdown editor.",
   "main": "lib/textarea-markdown.js",
   "scripts": {

--- a/src/textarea-markdown.js
+++ b/src/textarea-markdown.js
@@ -190,18 +190,18 @@ export default class TextareaMarkdown {
 
   async replacePlaceholderTag(placeholderTag, filename, fileSize, url) {
     const commonPlaceholderTag = placeholderTag
-      .replace(/%filename/, filename)
-      .replace(/%url/, url);
+      .replace(/%filename/g, filename)
+      .replace(/%url/g, url);
 
     if (placeholderTag === this.options.uploadImageTag) {
       const dimensions = await this.fetchImageDimensions(url);
       return commonPlaceholderTag
-        .replace(/%width/, dimensions.width)
-        .replace(/%height/, dimensions.height);
+        .replace(/%width/g, dimensions.width)
+        .replace(/%height/g, dimensions.height);
     } else if (placeholderTag === this.options.uploadVideoTag) {
       return commonPlaceholderTag;
     } else {
-      return commonPlaceholderTag.replace(/%fileSize/, fileSize);
+      return commonPlaceholderTag.replace(/%fileSize/g, fileSize);
     }
   }
 


### PR DESCRIPTION
@komagata Hello!

I would like to update textarea-markdown in relation to [this Issue](https://github.com/fjordllc/bootcamp/issues/7303#issuecomment-2310981732). Please check the content.

# Change Summary

Previously, only the first matched string was replaced even if there were multiple replacement target strings in the uploadTag.
With this change, all matched replacement strings are replaced.

# Change Detail

A sample uploadTag is shown below:

```js
uploadImageTag:
          '<a href="%url" target="_blank" rel="noopener noreferrer"><img src="%url" width="%width" height="%height" alt="%filename"></a>\n',

```

# before

Conventionally, only the first matched string is replaced.

![image](https://github.com/user-attachments/assets/bcb93042-2af7-4eb1-b010-3ac28a502b3a)


# after

After the change, all target strings to be replaced should be replaced.

![image](https://github.com/user-attachments/assets/2618d63c-a524-4dfa-84ac-6a86a1d5abc0)
