### PR TITLE
Allow passing arguments to Markdown-it plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,27 @@ import TextareaMarkdown from 'textarea-markdown'
 let textarea = document.querySelector('textarea');
 new TextareaMarkdown(textarea);
 ```
+
+#### plugins
+- type: Array
+- default: []
+
+An array of Markdown-It plugins to apply.  
+Each plugin can be either:
+- a function (plugin)
+- or an array like `[plugin, option1, option2, ...]`
+
+**Example**
+
+```javascript
+import TextareaMarkdown from 'textarea-markdown'
+import markdownItEmoji from 'markdown-it-emoji'
+import markdownItSub from 'markdown-it-sub'
+
+new TextareaMarkdown(textarea, {
+  plugins: [
+    markdownItEmoji,
+    [markdownItSub, { delimiter: '~' }]
+  ]
+})
+```

--- a/lib/textarea-markdown.js
+++ b/lib/textarea-markdown.js
@@ -16,6 +16,10 @@ var _filesize = require("filesize");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
+function _toArray(arr) { return Array.isArray(arr) ? arr : Array.from(arr); }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var FileType = require("file-type/browser");
@@ -147,15 +151,21 @@ var TextareaMarkdown = function () {
 
       var markdownOptions = this.options["markdownOptions"];
       var plugins = this.options["plugins"];
-      if (this.previews) {
-        this.previews.forEach(function (preview) {
-          var md = new _markdownIt2.default(markdownOptions);
-          plugins.forEach(function (plugin) {
-            return md.use(plugin);
-          });
-          preview.innerHTML = md.render(_this3.textarea.value);
+      this.previews.forEach(function (preview) {
+        var md = new _markdownIt2.default(markdownOptions);
+        plugins.forEach(function (pluginEntry) {
+          if (Array.isArray(pluginEntry)) {
+            var _pluginEntry = _toArray(pluginEntry),
+                plugin = _pluginEntry[0],
+                pluginArgs = _pluginEntry.slice(1);
+
+            md.use.apply(md, [plugin].concat(_toConsumableArray(pluginArgs)));
+          } else {
+            md.use(pluginEntry);
+          }
         });
-      }
+        preview.innerHTML = md.render(_this3.textarea.value);
+      });
 
       this.options["afterPreview"]();
     }

--- a/src/textarea-markdown.js
+++ b/src/textarea-markdown.js
@@ -102,13 +102,18 @@ export default class TextareaMarkdown {
   applyPreview() {
     const markdownOptions = this.options["markdownOptions"];
     const plugins = this.options["plugins"];
-    if (this.previews) {
-      this.previews.forEach((preview) => {
-        let md = new MarkdownIt(markdownOptions);
-        plugins.forEach((plugin) => md.use(plugin));
-        preview.innerHTML = md.render(this.textarea.value);
+    this.previews.forEach((preview) => {
+      let md = new MarkdownIt(markdownOptions);
+      plugins.forEach((pluginEntry) => {
+        if (Array.isArray(pluginEntry)) {
+          const [plugin, ...pluginArgs] = pluginEntry;
+          md.use(plugin, ...pluginArgs);
+        } else {
+          md.use(pluginEntry);
+        }
       });
-    }
+      preview.innerHTML = md.render(this.textarea.value);
+    });
 
     this.options["afterPreview"]();
   }


### PR DESCRIPTION
## Overview

This PR improves the plugin registration logic for Markdown-it in TextareaMarkdown.
Previously, you could only pass plugins without options.
Now you can pass an array where the first element is the plugin, and the rest are arguments for that plugin.

## Changes 

* Updated the applyPreview() method to handle plugin arguments.
* No changes to constructor options or existing configuration keys.
* Updated the README to document this new way of passing plugin arguments.

### example

```javascript
new TextareaMarkdown(textarea, {
  plugins: [
    pluginWithoutOptions,
    [pluginWithOptions, { optionKey: 'value' }]
  ]
});
```

## Notes
* Backward compatible with existing plugin registrations.